### PR TITLE
fixed execution directory restriction

### DIFF
--- a/api_mlflow/model/app.py
+++ b/api_mlflow/model/app.py
@@ -1,15 +1,19 @@
-from fastapi import FastAPI, HTTPException, Query
-from pydantic import BaseModel, Field
+from fastapi import FastAPI, Query
+from pydantic import BaseModel
 from typing import List, Optional, Tuple
 import uvicorn
 import subprocess
+import sys
 from train_model import \
 SEED, VALIDATION_SPLIT, VAL_TST_SPLIT_ENUM, VAL_TST_SPLIT, CHNLS, DROPOUT_RATE, INIT_WEIGHTS, \
     IMAGE_SIZE, BATCH_SIZE, BASE_LEARNING_RATE, FINE_TUNE_AT, INITIAL_EPOCHS, FINE_TUNE_EPOCHS
 
 title = 'Training API'
 pthn = 'python3'
-scrpt = 'mlflow_train.py'
+f_path = sys.argv[0]
+d_path_end = f_path.rfind('/')
+d_path = sys.argv[0][:d_path_end + 1]
+scrpt = d_path + 'mlflow_train.py'
 i_flg = '-i'
 p_flg = '-p'
 d_flg = '-d'

--- a/api_mlflow/model/mlflow_train.py
+++ b/api_mlflow/model/mlflow_train.py
@@ -3,8 +3,7 @@ script that performs the (re)training of the (target) model thus producing a new
 '''
 
 import sys
-sys.path.insert(1, '../')
-from model.train_model import TrainPR, IMAGE_SIZE, BATCH_SIZE, BASE_LEARNING_RATE, FINE_TUNE_AT, INITIAL_EPOCHS, FINE_TUNE_EPOCHS
+from train_model import TrainPR, IMAGE_SIZE, BATCH_SIZE, BASE_LEARNING_RATE, FINE_TUNE_AT, INITIAL_EPOCHS, FINE_TUNE_EPOCHS
 from predict_model import prdct, show_clsf_rprt, show_conf_mtrx
 import mlflow
 from mlflow_utils import create_mlflow_xprmnt, dt_stamp, print_run_info, print_xprmnt_info


### PR DESCRIPTION
# What is it?

- [X] Bug

# Why is it needed?

To be able to access 'mlflow_train.py' via 'app.py' from any (current) directory

# Checklist:

- [X] I have performed a self-review of my own code
- [X] Performed tests to cover the fix / functionality